### PR TITLE
Change the discourse and docs links

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -21,7 +21,7 @@
           <a href="/docs">Docs</a>
         </li>
         <li class="p-navigation__link" role="menuitem">
-          <a href="https://discourse.charmed-kubeflow.io">Discourse</a>
+          <a href="https://discourse.juju.is/c/kubeflow">Discourse</a>
         </li>
         <li class="p-navigation__link" role="menuitem">
           <a class="p-link--external" href="https://github.com/juju-solutions/bundle-kubeflow">Code</a>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -23,9 +23,9 @@ session = talisker.requests.get_session()
 
 
 doc_parser = DocParser(
-    api=DiscourseAPI(base_url="https://discourse.dqlite.io/", session=session),
-    index_topic_id=21,
-    category_id=5,
+    api=DiscourseAPI(base_url="https://discourse.juju.is/", session=session),
+    index_topic_id=3530,
+    category_id=14,
     url_prefix="/docs",
 )
 


### PR DESCRIPTION
## Done
Change the discourse and docs links

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Click Docs in the navigation and see it renders a blank docs for now
- Click discourse and see it lands in the Kubeflow category on juju.is 
