### PR TITLE
Fix seo issues

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -40,7 +40,7 @@
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2" crossorigin>
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
 
-  <meta name="description" content="{% block meta_description %}{% endblock %}">
+  <meta name="description" content="{% block meta_description %}Open source Python operators for Kubeflow on-rails. For workstations, multi-cloud and edge.{% endblock %}">
 
   <meta name="theme-color" content="#414BB2">
   <meta property="og:type" content="website">

--- a/templates/index.html
+++ b/templates/index.html
@@ -381,7 +381,7 @@
       <p>With the expansion of Kubeflow as a full ML toolkit, running it on desktops with up to 16Gb of RAM has become a painful experience.</p>
       <p>Kubeflow-lite is a lightweight version of Kubeflow with the ML services you typically need on your desktop, on a smooth experience.</p>
       <p>
-        <a href="https://jaas.ai/u/kubeflow-charmers/kubeflow-lite" class="p-link--external">Learn more</a>
+        <a href="https://jaas.ai/u/kubeflow-charmers/kubeflow-lite" class="p-link--external">Kubeflow-lite</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">


### PR DESCRIPTION
## Done

- Add meta description
- Change link name from "Learn more" to "Kubeflow-lite". Lighthouse failed as "learn more" is too generic. [Read more here](https://web.dev/link-text/?utm_source=lighthouse&utm_medium=devtools)


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Run the lighthouse audit and check SEO audit is 100. 


## Issue / Card

Fixes #7 

## Screenshots

<img src="https://user-images.githubusercontent.com/58959073/93605801-226f2300-f9bf-11ea-9f4f-fe2ec60df331.png" width = "450" height = "400" />

