### PR TITLE
Update topology and box images

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
     <div class="col-6 u-align--center u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/4595d39d-Topology-sml-green.svg",
+          url="https://assets.ubuntu.com/v1/10400c98-Charmed-kubeflow-Topology-header.svg",
           alt="",
           width="350",
           height="312",
@@ -112,7 +112,7 @@
     <div class="col-5 u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/179dcd07-Kubeflow-packaged.svg",
+          url="https://assets.ubuntu.com/v1/7c6d52ef-Kubeflow-nicely-packaged-box.svg",
           alt="",
           width="208",
           height="197",


### PR DESCRIPTION
## Done

- Update images on homepage as requested

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check Topology header matches:
https://assets.ubuntu.com/v1/10400c98-Charmed-kubeflow-Topology-header.svg
and Nicely packaged box matches:
https://assets.ubuntu.com/v1/7c6d52ef-Kubeflow-nicely-packaged-box.svg

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/95197006-d13d9c80-07d0-11eb-9f7e-cbb9cfbcd9e3.png)


![image](https://user-images.githubusercontent.com/58959073/95197023-d69ae700-07d0-11eb-8bf4-2fd76374921e.png)

