### PR TITLE
Integrate cookie-policy v3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@canonical/global-nav": "2.4.3",
+    "@canonical/cookie-policy": "3.0.4",
     "autoprefixer": "9.8.6",
     "babel-eslint": "10.1.0",
     "eslint": "7.8.1",

--- a/static/js/cookie-policy.js
+++ b/static/js/cookie-policy.js
@@ -1,0 +1,3 @@
+import { cookiePolicy } from "@canonical/cookie-policy";
+
+cookiePolicy();

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -4,6 +4,9 @@
 // Import Vanilla
 @import "vanilla-framework/scss/build";
 
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";
+
 // Local styles
 @import "pattern_strips";
 @import "pattern_navigation";

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -40,7 +40,7 @@
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2" crossorigin>
   <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2" crossorigin>
 
-  
+
   <meta name="description" content="{% block meta_description %}Open source Python operators for Kubeflow on-rails. For workstations, multi-cloud and edge.{% endblock %}">
   <meta name="copydoc" content="https://docs.google.com/document/d/1Wvhl0yYV_w0BJsyZbQFKg_QV6RjMLbmQU3x0rsD2F4Q/edit">
 
@@ -69,6 +69,7 @@
   <!-- End Google Tag Manager (noscript) -->
 
   <script src="{{ versioned_static('js/dist/global-nav.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
 
   {% include "partial/_navigation.html" %}
 

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -10,6 +10,9 @@
             </a>
           </li>
           <li class="p-inline-list__item">
+            <a class="js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+          </li>
+          <li class="p-inline-list__item">
             <a aria-label="External link to report a bug on this site" href="https://github.com/canonical-web-and-design/charmed-kubeflow.io/issues/new">
               Report a bug on this site
             </a>

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -1,4 +1,5 @@
 module.exports = {
   "global-nav": "./static/js/global-nav.js",
+  "cookie-policy": "./static/js/cookie-policy.js",
   base: "./static/js/base.js",
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,6 +1400,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@canonical/cookie-policy@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.4.tgz#c2d6d990dc0993344a9bf5c244374e3f51fe34f1"
+  integrity sha512-pI65cRFh9xU2xo3d9R8ifGbQoH72tk3p8xh/4ANuj9kREeh9G/gcim/iHQS7IffSocHT9l6ZtUXBcQ12m/CBMw==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done
- Integrate cookie policy 3.0.4

## QA
- Pull the branch
- Run the site using the dotrun snap with `$ dotrun clean` then `$dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8046/
- Check the cookie policy appears
- Check the manager opens and works
- Make a selection and the notification should disappear
- Scroll to the footer and click the Manage link in the footer
- See that manager appears again. 

## Issue / Card
Fixes https://github.com/canonical-web-and-design/charmed-kubeflow.io/issues/22
