### PR TITLE
Update the brand colour to Ubuntu orange

### DIFF
--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -1,5 +1,5 @@
 // Colours
-$color-brand: #414bb2;
+$color-brand: #e95420;
 $color-suru-start: #4d4d4d;
 $color-suru-middle: #333;
 $color-suru-end: #1a1a1a;


### PR DESCRIPTION
## Done
Update the brand colour to Ubuntu orange

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Check the logo is on orange
- Check the subtle accent colors are now orange

## Screenshot
![image](https://user-images.githubusercontent.com/1413534/98388208-5f17dc00-204a-11eb-86f0-3e24533f5c3c.png)


![image](https://user-images.githubusercontent.com/1413534/98388240-6b039e00-204a-11eb-8ea3-6681d8d4101c.png)
