### PR TITLE
Fixup page titles

### DIFF
--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -7,7 +7,7 @@
   <meta https-equiv="Accept-CH" content="DPR, Viewport-Width, Width">
 
   <title>
-    {% block title %}Charmed Kubeflow - Run Kubeflow anywhere, easily{% endblock %}
+    {% block title %}Run Kubeflow anywhere, easily{% endblock %} | Charmed Kubeflow
   </title>
 
   <link rel="preconnect" href="https://www.google-analytics.com">

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -1,6 +1,6 @@
 {% extends 'base_layout.html' %}
 
-{% block page_title %}Chamred Kubenetes | Contact us{% endblock %}
+{% block title %}Contact us{% endblock %}
 {% block meta_copydoc %}{% endblock meta_copydoc %}
 
 

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -2,7 +2,7 @@
 
 {% block page_class %}docs{% endblock %}
 {% block content_class %}l-docs-wrapper{% endblock %}
-{% block page_title %}| {{ document.title }} {% endblock %}
+{% block title %}{{ document.title }} | Documentation{% endblock %}
 
 {% block content %}
 <div class="p-strip is-shallow">

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,5 @@
 {% extends 'base_layout.html' %}
+{% block title %}Run Kubeflow anywhere, easily{% endblock %}
 {% block meta_description %}Open source Python operators for Kubeflow on-rails. For workstations, multi-cloud and edge.{% endblock meta_description%}
 
 {% block content %}

--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -1,6 +1,6 @@
 {% extends 'base_layout.html' %}
 
-{% block page_title %}Chamred Kubeflow | Thank you{% endblock %}
+{% block title %}Thank you{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

- Fixed page titles across the site, the block `page_title` and `title` overlapped

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046/docs
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that docs, contact-us, thank-you and the homepage have logical titles


## Issue / Card

Fixes #30