### PR TITLE
Update to charmhub.io link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -278,7 +278,7 @@
     <div class="col-6">
       <h2>Open source operators in Python</h2>
       <p class="p-heading--four u-sv2">Small, composable, model-driven Kubernetes charms</p>
-      <p>Make use of open source integration code and compound the benefit of <a href="https://jaas.ai/store" class="p-link--external">100+ available operators</a>.</p>
+      <p>Make use of open source integration code and compound the benefit of <a href="https://charmhub.io/" class="p-link--external">100+ available operators</a>.</p>
       <p>Charms make deploying and managing Kubeflow simple to your IT ops team. No hard-coded services, evergreen operations.</p>
       <p>Engineered for flexibility around complex scenarios, charms allow you to tailor Kubeflow to your needs with custom integrations.</p>
       <p>


### PR DESCRIPTION
## Done

- update link from jaas.ai/store to charmhub.io

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve comments in the [copy doc](https://docs.google.com/document/d/1Wvhl0yYV_w0BJsyZbQFKg_QV6RjMLbmQU3x0rsD2F4Q/edit?ts=5fb65a9c#)


## Issue / Card

Fixes #32 
