### PR TITLE
Update install and reference arch links

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
         <p class="p-heading--4">Pure open source Python operators put Kubeflow on rails, for bare metal, VMware and multi-cloud or edge.</p>
         <p>Composable operators for data scientists to stand up and integrate the Kubeflow applications they need, on a laptop, workstation or cluster. Upgrades and security updates all supported in the free version.</p>
         <p>
-          <a href="http://ubuntu.com/kubeflow/install" class="p-button--positive p-link--external">Get running in 5 minutes</a>
+          <a href="/docs/install" class="p-button--positive">Get running in 5 minutes</a>
           <a href="/contact-us" class="p-button--neutral js-invoke-modal">Get in touch</a>
         </p>
       </div>
@@ -94,7 +94,7 @@
       <p>Unleash your data scientists with the latest ML tools in a single dashboard. All-in-one toolkit, one-time-config.</p>
       <p>No more siloed notebooks and scripts, reproducible and shareable AI workflows with <a href="https://ubuntu.com/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1" class="p-link--external">Kubeflow pipelines</a>.</p>
       <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="http://ubuntu.com/kubeflow/install" class="p-button--positive p-link--external">Install Kubeflow</a></li>
+        <li class="p-inline-list__item"><a href="/docs/install" class="p-button--positive">Install Kubeflow</a></li>
         <li class="p-inline-list__item"><a href="https://ubuntu.com/tutorials/deploy-kubeflow-ubuntu-windows-mac#1-overview" class="p-link--external">Follow tutorial</a></li>
         <li class="p-inline-list__item"><a href="https://ubuntu.com/kubeflow/what-is-kubeflow" class="p-link--external">What is Kubeflow?</a></li>
       </ul>
@@ -464,10 +464,9 @@
       <p>Enjoy a public cloud like experience on-prem with <a class="p-link--external" href="http://maas.io">Metal As A Service</a>.</p>
       <p>Charms integrate your networking and storage of choice with logging, monitoring and alerting solutions, Kubernetes and Kubeflow.</p>
       <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="https://ubuntu.com/kubernetes" class="p-link--external">Dell and Canonical Reference Architecture</a></li>
+        <li class="p-inline-list__item"><a href="https://ubuntu.com/engage/dell-k8s-reference-architecture" class="p-link--external">Dell and Canonical Reference Architecture</a></li>
         <li class="p-inline-list__item"><a href="/contact-us" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></li>
       </ul>
-      </p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Update install and reference arch links
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that links are not to the local /docs/install or the k8s ref arch engage page


## Issue / Card

Fixes #36
