### PR TITLE
Update Dell ref arch link to new engage page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -464,7 +464,7 @@
       <p>Enjoy a public cloud like experience on-prem with <a class="p-link--external" href="http://maas.io">Metal As A Service</a>.</p>
       <p>Charms integrate your networking and storage of choice with logging, monitoring and alerting solutions, Kubernetes and Kubeflow.</p>
       <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="https://ubuntu.com/engage/dell-k8s-reference-architecture" class="p-link--external">Dell and Canonical Reference Architecture</a></li>
+        <li class="p-inline-list__item"><a href="https://ubuntu.com/engage/dell-kubeflow-reference-architecture" class="p-link--external">Dell and Canonical Reference Architecture</a></li>
         <li class="p-inline-list__item"><a href="/contact-us" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

- Updated the link to Dell reference architecture to the new engage page
- Updated the [copy doc](https://docs.google.com/document/d/1Wvhl0yYV_w0BJsyZbQFKg_QV6RjMLbmQU3x0rsD2F4Q/edit?ts=60070ea5#) with the new link

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link 'Dell and Canonical Reference Architecture' now goes to https://ubuntu.com/engage/dell-kubeflow-reference-architecture

