### PR TITLE
Update links on charmed-kubeflow.io homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -94,7 +94,7 @@
       <p>Unleash your data scientists with the latest ML tools in a single dashboard. All-in-one toolkit, one-time-config.</p>
       <p>No more siloed notebooks and scripts, reproducible and shareable AI workflows with <a href="https://ubuntu.com/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1" class="p-link--external">Kubeflow pipelines</a>.</p>
       <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a href="/docs/install" class="p-button--positive">Install Kubeflow</a></li>
+        <li class="p-inline-list__item"><a href="/docs/install" class="p-button--positive">Install Kubeflow&nbsp;&rsaquo;</a></li>
         <li class="p-inline-list__item"><a href="https://ubuntu.com/tutorials/deploy-kubeflow-ubuntu-windows-mac#1-overview" class="p-link--external">Follow tutorial</a></li>
         <li class="p-inline-list__item"><a href="https://ubuntu.com/kubeflow/what-is-kubeflow" class="p-link--external">What is Kubeflow?</a></li>
       </ul>
@@ -267,7 +267,7 @@
       <p>From experimentation with <a href="https://microk8s.io" class="p-link--external">MicroK8s</a> on desktop or one cloud node, to large scale <a href="https://ubuntu.com/kubernetes" class="p-link--external">multi-cloud Kubernetes</a>.</p>
       <p>Multi-cloud Kubeflow delivers the elasticity of the public clouds and the cost-effective compute of on-prem.</p>
       <p>
-        <a href="https://jaas.ai/kubeflow/bundle/185" class="p-button--neutral p-link--external">Deploy Kubeflow at scale</a>
+        <a href="/docs/install" class="p-button--neutral">Deploy Kubeflow at scale</a>
       </p>
     </div>
   </div>
@@ -372,7 +372,6 @@
       <p>Easy setup on public cloud Kubernetes for a multi-cloud Kubeflow. Get the elasticity of the public clouds and the cost-effective compute of on-prem.</p>
       <p>On-rails deployment and management with Python operators on public cloud Kubernetes services &mdash; AKS, EKS, GKE.</p>
       <p><a href="https://ubuntu.com/kubernetes" class="p-link--external">Kubeflow on multi-cloud K8s</a></p>
-      </p>
     </div>
   </div>
 </section>
@@ -385,8 +384,8 @@
       <p>With the expansion of Kubeflow as a full ML toolkit, running it on desktops with up to 16Gb of RAM has become a painful experience.</p>
       <p>Kubeflow-lite is a lightweight version of Kubeflow with the ML services you typically need on your desktop, on a smooth experience.</p>
       <p>
-        <a href="/docs/install/kubeflow-lite" class="p-button--positive">Install Kubeflow lite</a>
-        <a href="https://jaas.ai/u/kubeflow-charmers/kubeflow-lite" class="p-link--external">Learn more about Kubeflow-lite</a>
+        <a href="/docs/install" class="p-button--positive">Install Kubeflow lite</a>
+        <a href="/docs/operators-and-bundles">Learn more about Kubeflow-lite&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--small">
@@ -480,8 +479,8 @@
       <p>Alternatively, build your custom Kubeflow bundle with the charmed apps you need, well integrated.</p>
       <p>On MicroK8s or any conformant Kubernetes.</p>
       <p>
-        <a href="/docs/install/kubeflow-edge" class="p-button--positive">Install Kubeflow edge</a>
-        <a href="https://jaas.ai/u/kubeflow-charmers/kubeflow-edge" class="p-link--external">Learn about Kubeflow-edge</a>
+        <a href="/docs/install" class="p-button--positive">Install Kubeflow edge</a>
+        <a href="/docs/operators-and-bundles">Learn about Kubeflow-edge&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-hide--small u-vertically-center">


### PR DESCRIPTION
## Done

- Update links per the [copy doc](https://docs.google.com/document/d/1Wvhl0yYV_w0BJsyZbQFKg_QV6RjMLbmQU3x0rsD2F4Q/edit?usp=drivesdk)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the links all work


## Issue / Card

Fixes #43
