### PR TITLE
Add inclusive naming action

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout master
+      - name: Checkout main
         uses: actions/checkout@v2
 
       - name: Install linkchecker

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,3 +103,17 @@ jobs:
         run: |
           yarn test-js
           bash <(curl -s https://codecov.io/bash) -cF javascript
+          
+  check-inclusive-naming:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check inclusive naming
+        uses: canonical-web-and-design/inclusive-naming@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # charmed-kubeflow.io
 
-[![Code coverage](https://codecov.io/gh/canonical-web-and-design/charmed-kubeflow.io/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/charmed-kubeflow.io)
+[![Code coverage](https://codecov.io/gh/canonical-web-and-design/charmed-kubeflow.io/branch/main/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/charmed-kubeflow.io)
 
 This is the repo for the [charmed-kubeflow.io website](https://charmed-kubeflow.io).
 


### PR DESCRIPTION
## Done

- Adds inclusive naming github action
- Replaces key non-inclusive language

**TODO**: Rename 'master' to 'main'

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check github action works
- Check language changes make lexical sense

## Issue / Card

Fixes https://app.zenhub.com/workspaces/-web-squad-5931746dba512f05402b61f6/issues/canonical-web-and-design/web-squad/4479
