### PR TITLE
Add dynamic tutorials page

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -6,6 +6,16 @@ env:
   - name: SENTRY_DSN
     value: https://b365f83c60744cfea7b229836cad4eca@sentry.is.canonical.com//42
 
+  - name: DISCOURSE_API_KEY
+    secretKeyRef:
+      key: charmhub-api-key
+      name: discourse-api
+      
+  - name: DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key: charmhub-api-username
+      name: discourse-api
+
 # Overrides for production
 production:
   replicas: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 canonicalwebteam.flask-base==1.0.3
 canonicalwebteam.discourse==4.0.8
 canonicalwebteam.image-template==1.3.1
+canonicalwebteam.templatefinder==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 canonicalwebteam.flask-base==1.0.3
 canonicalwebteam.discourse==4.0.8
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.templatefinder==1.0.0

--- a/static/sass/_layout_tutorials.scss
+++ b/static/sass/_layout_tutorials.scss
@@ -1,0 +1,53 @@
+@mixin layout-tutorials {
+  $color-highlight: #77216f !default;
+
+  .l-tutorials__breadcrumb {
+    display: none;
+
+    @media only screen and (min-width: $breakpoint-small) {
+      display: block;
+    }
+  }
+
+  .l-tutorials__filters {
+    background-color: $color-x-light;
+    box-shadow: 4px 0 4px rgba(0, 0, 0, 0.3);
+  }
+
+  .l-tutorials-card__footer--inner {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .l-tutorials-meter {
+    background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
+    background-position-x: -75px;
+    background-position-y: center;
+    background-repeat: no-repeat;
+    display: inline-block;
+    height: $sp-large;
+    margin-left: $sp-xx-small;
+    text-indent: -9999px;
+    width: 74px;
+  }
+
+  .l-tutorials-meter--1 {
+    background-position-x: -60px;
+  }
+
+  .l-tutorials-meter--2 {
+    background-position-x: -45px;
+  }
+
+  .l-tutorials-meter--3 {
+    background-position-x: -30px;
+  }
+
+  .l-tutorials-meter--4 {
+    background-position-x: -15px;
+  }
+
+  .l-tutorials-meter--5 {
+    background-position-x: 0;
+  }
+}

--- a/static/sass/_layout_tutorials.scss
+++ b/static/sass/_layout_tutorials.scss
@@ -1,24 +1,6 @@
 @mixin layout-tutorials {
   $color-highlight: #77216f !default;
 
-  .l-tutorials__breadcrumb {
-    display: none;
-
-    @media only screen and (min-width: $breakpoint-small) {
-      display: block;
-    }
-  }
-
-  .l-tutorials__filters {
-    background-color: $color-x-light;
-    box-shadow: 4px 0 4px rgba(0, 0, 0, 0.3);
-  }
-
-  .l-tutorials-card__footer--inner {
-    display: flex;
-    justify-content: space-between;
-  }
-
   .l-tutorials-meter {
     background-image: url("#{$assets-path}19c4273e-level+of+difficulty.svg");
     background-position-x: -75px;

--- a/static/sass/_pattern_blog-card.scss
+++ b/static/sass/_pattern_blog-card.scss
@@ -1,26 +1,4 @@
 @mixin blog-p-card {
-  .blog-p-card__category {
-    background: url("#{$assets-path}ed42aefa-icon-resource-hub-icon-document.png")
-      left center no-repeat;
-    color: $color-mid-dark;
-    font-size: $sp-medium;
-    line-height: 1.5;
-    padding: 0 0 0 $sp-large;
-    text-transform: uppercase;
-
-    > a:link,
-    > a:visited {
-      color: $color-mid-dark;
-      text-decoration: none;
-    }
-
-    > a:hover,
-    > a:active {
-      color: $color-brand;
-      text-decoration: underline;
-    }
-  }
-
   %post-card-header {
     border-radius: 2px;
     padding: $sp-medium $sp-medium $sp-small;
@@ -32,12 +10,6 @@
     display: flex !important;
     flex-direction: column;
     padding: 0;
-
-    .p-strip--featured & {
-      background-color: rgba(255, 255, 255, 0.9);
-      position: relative;
-      z-index: 1;
-    }
 
     > .blog-p-card__content {
       border-top: 1px dotted $color-mid-light;
@@ -67,33 +39,5 @@
   .blog-p-card__header--tutorial {
     @extend %post-card-header;
     border-top: 3px solid #77216f;
-  }
-
-  .blog-p-card--muted {
-    @extend .p-card;
-
-    background-color: $color-light;
-    box-shadow: 0 1px 2px 0 transparentize($color-dark, 0.8);
-    padding: 0;
-
-    > .blog-p-card__header {
-      border-bottom: 0;
-      border-top: 3px solid $color-light;
-      margin-bottom: 0;
-    }
-
-    > .blog-p-card__content {
-      border-top: 1px dotted $color-mid-light;
-      margin: 0 $sp-small $sp-small;
-      padding: $sp-medium $sp-small $sp-small;
-    }
-  }
-
-  .blog-p-card__date {
-    @extend .p-media-object__meta-list;
-
-    display: flex;
-    margin-top: auto;
-    padding-top: $sp-medium;
   }
 }

--- a/static/sass/_pattern_blog-card.scss
+++ b/static/sass/_pattern_blog-card.scss
@@ -1,0 +1,99 @@
+@mixin blog-p-card {
+  .blog-p-card__category {
+    background: url("#{$assets-path}ed42aefa-icon-resource-hub-icon-document.png")
+      left center no-repeat;
+    color: $color-mid-dark;
+    font-size: $sp-medium;
+    line-height: 1.5;
+    padding: 0 0 0 $sp-large;
+    text-transform: uppercase;
+
+    > a:link,
+    > a:visited {
+      color: $color-mid-dark;
+      text-decoration: none;
+    }
+
+    > a:hover,
+    > a:active {
+      color: $color-brand;
+      text-decoration: underline;
+    }
+  }
+
+  %post-card-header {
+    border-radius: 2px;
+    padding: $sp-medium $sp-medium $sp-small;
+  }
+
+  .blog-p-card--post {
+    @extend %p-card--highlighted;
+
+    display: flex !important;
+    flex-direction: column;
+    padding: 0;
+
+    .p-strip--featured & {
+      background-color: rgba(255, 255, 255, 0.9);
+      position: relative;
+      z-index: 1;
+    }
+
+    > .blog-p-card__content {
+      border-top: 1px dotted $color-mid-light;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      margin: 0 $sp-small;
+      padding: $sp-medium $sp-small $sp-small;
+
+      > a,
+      h3,
+      p {
+        display: block;
+        margin: $sp-small 0;
+      }
+    }
+
+    .blog-p-card__footer {
+      border-top: 1px dotted $color-mid-light;
+      font-size: 0.875rem;
+      margin: auto $sp-small 0;
+      max-width: inherit;
+      padding: $sp-medium $sp-small;
+    }
+  }
+
+  .blog-p-card__header--tutorial {
+    @extend %post-card-header;
+    border-top: 3px solid #77216f;
+  }
+
+  .blog-p-card--muted {
+    @extend .p-card;
+
+    background-color: $color-light;
+    box-shadow: 0 1px 2px 0 transparentize($color-dark, 0.8);
+    padding: 0;
+
+    > .blog-p-card__header {
+      border-bottom: 0;
+      border-top: 3px solid $color-light;
+      margin-bottom: 0;
+    }
+
+    > .blog-p-card__content {
+      border-top: 1px dotted $color-mid-light;
+      margin: 0 $sp-small $sp-small;
+      padding: $sp-medium $sp-small $sp-small;
+    }
+  }
+
+  .blog-p-card__date {
+    @extend .p-media-object__meta-list;
+
+    display: flex;
+    margin-top: auto;
+    padding-top: $sp-medium;
+  }
+}

--- a/static/sass/_pattern_tutorial.scss
+++ b/static/sass/_pattern_tutorial.scss
@@ -1,0 +1,89 @@
+@mixin pattern-tutorial {
+  .p-tutorial__nav-title {
+    padding-left: 2rem;
+    position: relative;
+
+    &::before {
+      height: $sp-large;
+      left: 0;
+      margin-right: $sp-medium;
+      position: absolute;
+      width: $sp-large;
+    }
+
+    .is-active & {
+      font-weight: 400;
+
+      &::before {
+        background-color: $color-brand;
+        color: $color-x-light;
+        font-weight: 300;
+      }
+    }
+  }
+
+  .p-tutorial__nav-link {
+    color: $color-dark;
+
+    &:visited {
+      color: $color-dark;
+    }
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .p-tutorial-content {
+    margin-top: -20rem;
+  }
+
+  .p-tutorial-section {
+    display: none;
+
+    &:target {
+      display: block;
+      padding-top: 20rem;
+    }
+  }
+
+  .p-tutorial__pagination {
+    @media only screen and (min-width: $breakpoint-small) {
+      display: inline-block;
+    }
+  }
+
+  .p-tutorial__pagination-item--prev {
+    .p-icon--contextual-menu {
+      transform: rotate(90deg);
+    }
+  }
+
+  .p-tutorial__pagination-item--next {
+    .p-icon--contextual-menu {
+      transform: rotate(-90deg);
+    }
+  }
+
+  .p-tutorial__feedback-icon {
+    cursor: pointer;
+  }
+
+  .p-tutorial__feedback-options {
+    .p-inline-list__item {
+      .has-color {
+        display: none;
+      }
+
+      &:hover {
+        .p-tutorial__feedback-icon {
+          display: none;
+        }
+
+        .has-color {
+          display: inline-block;
+        }
+      }
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -10,6 +10,10 @@
 // Local styles
 @import "pattern_strips";
 @import "pattern_navigation";
+@import "pattern_blog-card";
+@import "layout_tutorials";
 
+@include layout-tutorials;
+@include blog-p-card;
 @include local-p-strips;
 @include local-p-navigation;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -12,7 +12,11 @@
 @import "pattern_navigation";
 @import "pattern_blog-card";
 @import "layout_tutorials";
+@import "pattern_tutorial";
 
+@include vf-p-icons;
+@include vf-p-buttons;
+@include pattern-tutorial;
 @include layout-tutorials;
 @include blog-p-card;
 @include local-p-strips;

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -26,6 +26,9 @@
         <li class="p-navigation__item" role="menuitem">
           <a class="p-navigation__link" href="https://discourse.charmhub.io/tags/kubeflow">Community</a>
         </li>
+        <li class="p-navigation__item {% if request.path.startswith('/tutorials') %}is-selected{% endif %}" role="menuitem">
+          <a class="p-navigation__link" href="/tutorials">Tutorials</a>
+        </li>
       </ul>
     </nav>
   </div>

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -13,15 +13,22 @@
 <section class="p-strip is-shallow">
   <div class="row u-equal-height">
     {% for item in tutorials %}
-      <div class="col-4 p-card">
-        <div class="p-card__content">
-          <h2 class="p-heading--4">
-            <a href="{{ item.link }}">{{ item.title | safe | truncate(50, true) }}</a>
-          </h2>
-          <p>{{ item.summary | safe }}</p>
-        </div>
-        <p>Difficulty: <span class="p-tutorials-meter p-tutorials-meter--{{ item.dificulty }}">{{ item.difficulty }} out of 5</span></p>
+    <div class="col-4 blog-p-card--post">
+      <header class="blog-p-card__header--tutorial">
+        <h5 class="p-muted-heading u-no-margin--bottom">
+          {{ item.categories.name }}
+        </h5>
+      </header>
+      <div class="blog-p-card__content">
+        <h3 class="p-heading--3 u-nomargin--top u-no-margin--bottom">
+          <a href="{{ item.link }}">{{ item.title | safe }}</a>
+        </h3>
+        <p class="u-sv3">{{ item.summary | safe }}</p>
       </div>
+      <footer class="blog-p-card__footer">
+        Difficulty:<span class="l-tutorials-meter l-tutorials-meter--{{ item.difficulty }}">{{ item.difficulty }} out of 5</span>
+      </footer>
+    </div>
     {% endfor %}
   </div>
 </section>

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -1,7 +1,8 @@
 {% extends 'base_layout.html' %}
 
-{% block title %}Tutorials{% endblock %}
+{% block title %}Charmed Kubeflow tutorials{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1YetdDlPGhz13jYG748DYsmIMlnaI6pA4glGzCsImzzA/edit#heading=h.jegvyy2vztti{% endblock %}
+{% block meta_description %}Learn what you can do with Charmed Kubeflow and how, through a series of tutorials. Deploy the Charmed Kubeflow AI/MLOps platform with 24/7 support on any cloud.{% endblock %}
 
 {% block content %}
 <section class="p-strip">

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -1,0 +1,29 @@
+{% extends 'base_layout.html' %}
+
+{% block title %}Tutorials{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1YetdDlPGhz13jYG748DYsmIMlnaI6pA4glGzCsImzzA/edit#heading=h.jegvyy2vztti{% endblock %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h1 class="p-heading--2">Tutorials</h1>
+  </div>
+</section>
+
+<section class="p-strip is-shallow">
+  <div class="row u-equal-height">
+    {% for item in tutorials %}
+      <div class="col-4 p-card">
+        <div class="p-card__content">
+          <h2 class="p-heading--4">
+            <a href="{{ item.link }}">{{ item.title | safe | truncate(50, true) }}</a>
+          </h2>
+          <p>{{ item.summary | safe }}</p>
+        </div>
+        <p>Difficulty: <span class="p-tutorials-meter p-tutorials-meter--{{ item.dificulty }}">{{ item.difficulty }} out of 5</span></p>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+
+{% endblock %}

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -5,13 +5,13 @@
 {% block meta_description %}Learn what you can do with Charmed Kubeflow and how, through a series of tutorials. Deploy the Charmed Kubeflow AI/MLOps platform with 24/7 support on any cloud.{% endblock %}
 
 {% block content %}
-<section class="p-strip">
+<section class="p-strip--suru-dark">
   <div class="u-fixed-width">
-    <h1 class="p-heading--2">Tutorials</h1>
+    <h1>Tutorials</h1>
   </div>
 </section>
 
-<section class="p-strip is-shallow">
+<section class="p-strip">
   <div class="row u-equal-height">
     {% for item in tutorials %}
     <div class="col-4 blog-p-card--post">

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -34,7 +34,7 @@
     </aside>
   </div>
   <div class="col-9">
-    <div class="p-strip is-shallow  p-tutorial-content">
+    <div class="p-strip is-shallow p-tutorial-content">
       {% for section in document.sections %}
         <section class="p-tutorial-section" id="{{ loop.index }}-{{ section['slug']}}">
           <h2 class="p-heading--3">{{ loop.index }}. {{ section["title"]}}</h2>
@@ -68,13 +68,14 @@
           {% endif %}
           
           <hr class="u-sv3">
-          <footer class="p-tutorial-section__footer row u-no-padding--left u-no-padding--right">
-            <div class="col-6 col-small-2 col-medium-3 u-vertically-center">
+          <footer class="row p-tutorial-section__footer u-no-padding--left u-no-padding--right">
+            <div class="col-3 u-vertically-center">
               <a class="p-tutorial__bug-link" href="https://discourse.jujucharms.com{{ document.topic_path }}">
                 <small>Suggest changes&nbsp;&rsaquo;</small>
               </a>
             </div>
-            <div class="col-6 col-small-2 col-medium-3 u-align--right">
+            <div class="col-3"></div>
+            <div class="col-3 u-align--right">
               <div class="p-tutorial__duration">
                 <small>
                   <span class="u-hide--small">about</span>
@@ -88,22 +89,22 @@
               </div>
               <div class="p-tutorial__pagination">
                 {% if loop.first %}
-                  <button class="p-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" disabled style="margin-right: 1rem;">
-                    <i class="p-icon--contextual-menu">Previous step</i>
+                  <button class="p-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom" disabled style="margin-right: 1rem;">
+                    <i class="p-icon--chevron-up">Previous step</i>
                   </button>
                 {% else %}
-                  <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}" class="p-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" style="margin-right: 1rem;">
-                    <i class="p-icon--contextual-menu">Previous step</i>
+                  <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}" class="p-tutorial__pagination-item--prev p-button has-icon u-no-margin--bottom" style="margin-right: 1rem;">
+                    <i class="p-icon--chevron-up">Previous step</i>
                   </a>
                 {% endif %}
 
                 {% if loop.last %}
-                  <button class="p-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom" disabled>
-                    <i class="p-icon--contextual-menu">Next step</i>
+                  <button class="p-tutorial__pagination-item--next p-button has-icon u-no-margin--bottom" disabled>
+                    <i class="p-icon--chevron-down">Next step</i>
                   </button>
                 {% else %}
-                  <a href="#{{ loop.index + 1 }}-{{ loop.nextitem['slug'] }}" class="p-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom">
-                    <i class="p-icon--contextual-menu">Next step</i>
+                  <a href="#{{ loop.index + 1 }}-{{ loop.nextitem['slug'] }}" class="p-tutorial__pagination-item--next p-button has-icon u-no-margin--bottom">
+                    <i class="p-icon--chevron-down">Next step</i>
                   </a>
                 {% endif %}
               </div>
@@ -115,5 +116,106 @@
   </div>
 </div>
 
+<script>
+  (function() {
+    const tutorialFeedbackOptions = document.querySelector('.p-tutorial__feedback-options');
+    const tutorialFeedbackIcons = document.querySelectorAll('.p-tutorial__feedback-icon');
+    const tutorialFeedbackResult = document.querySelector('.p-tutorial__feedback-result');
+
+    if (dataLayer) {
+      tutorialFeedbackIcons.forEach(icon => {
+        icon.addEventListener('click', e => {
+          const feedbackValue = e.target.getAttribute('data-feedback-value');
+          dataLayer.push({
+            'event' : 'GAEvent',
+            'eventCategory' : 'feedback',
+            'eventAction' : feedbackValue,
+            'eventLabel' : feedbackValue,
+            'eventValue' : undefined
+          });
+
+          tutorialFeedbackOptions.classList.add('u-hide');
+          tutorialFeedbackResult.classList.remove('u-hide');
+        });
+      });
+    }
+  })();
+</script>
+
+<script>
+(function() {
+  function setActiveLink(navigationItems) {
+    navigationItems.forEach(item => {
+      const link = item.querySelector('.p-tutorial__nav-link');
+      if (link.getAttribute('href') === window.location.hash) {
+        item.classList.add('is-active');
+      } else {
+        item.classList.remove('is-active');
+      }
+    });
+  };
+
+  const navigationItems = document.querySelectorAll('.p-tutorial__nav-item');
+  const toggleButton = document.querySelector('.p-tutorial__nav-toggle');
+
+  setActiveLink(navigationItems);
+
+  window.addEventListener('hashchange', e => {
+    e.preventDefault();
+    setActiveLink(navigationItems);
+  });
+
+  sectionIds = [];
+
+  const tutorialSections = document.querySelectorAll('.p-tutorial__content section');
+  tutorialSections.forEach(section => {
+    sectionIds.push(section.id);
+  });
+
+  // Navigate to first tutorial step on load if no URL hash
+  if (!window.location.hash) {
+    const firstSectionLink = document.querySelector('.p-tutorial__nav-link');
+    window.location.hash = firstSectionLink.getAttribute('href');
+  } else {
+    // Redirect #0, #1 etc. to the correct section
+    match = window.location.hash.match(/^#(\d+)$/);
+
+    if (match) {
+      index = parseInt(match[1]);
+      sectionId = sectionIds[index];
+      window.location.hash = `#${sectionId}`;
+      window.location.reload();
+    }
+  }
+})();
+</script>
+
+<script>
+  (function() {
+    const polls = document.querySelectorAll('.poll');
+
+    if (dataLayer) {
+      polls.forEach(poll => {
+        const answers = poll.querySelectorAll('[type="radio"]');
+        const pollId = poll.getAttribute('data-poll-name');
+
+        answers.forEach(answer => {
+          answer.addEventListener('change', e => {
+            const answerLabel = document.querySelector(`label[for="${e.target.id}"]`);
+            const eventLabel = answerLabel.innerText;
+            const eventAction = document.getElementById(pollId).innerText;
+            dataLayer.push({
+              'event' : 'GAEvent',
+              'eventCategory' : 'survey',
+              'eventAction' : eventAction,
+              'eventLabel' : eventLabel,
+              'eventValue' : undefined
+            });
+          });
+        });
+      });
+    }
+  })();
+</script>
 
 {% endblock %}

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -1,0 +1,119 @@
+{% extends 'base_layout.html' %}
+{% block title %}{{ document["title"] }}{% endblock %}
+
+{% block content %}
+
+<section class="p-strip--image is-shallow">
+  <div class="row">
+    <div class="col-10">
+      <h1 class="p-heading--2 u-no-margin--bottom">{{ document["title"] }}</h1>
+    </div>
+  </div>
+</section>
+<div class="row">
+  <div class="col-3">
+    <aside class="p-tutorial__sidenav" id="navigation">
+      <div class="u-hide--medium u-hide--large">
+        <i class="p-icon--menu"></i>
+      </div>
+      <div class="u-hide--small">
+        <nav>
+          <ol class="p-stepped-list p-tutorial__nav">
+            {% for section in document.sections %}
+              <li class="p-stepped-list__item p-tutorial__nav-item">
+                <p class="p-stepped-list__title p-tutorial__nav-title u-no-margin--bottom">
+                  <a href="#{{ loop.index }}-{{ section['slug'] }}" class="p-tutorial__nav-link">
+                    {{ section["title"]}}
+                  </a>
+                </p>
+              </li>
+            {% endfor %}
+          </ol>
+        </nav>
+      </div>
+    </aside>
+  </div>
+  <div class="col-9">
+    <div class="p-strip is-shallow  p-tutorial-content">
+      {% for section in document.sections %}
+        <section class="p-tutorial-section" id="{{ loop.index }}-{{ section['slug']}}">
+          <h2 class="p-heading--3">{{ loop.index }}. {{ section["title"]}}</h2>
+          <article>
+            {{ section.content | safe }}
+          </article>
+
+          {% if loop.last %}
+            <div class="p-tutorial__feedback-options">
+              <p>Was this tutorial useful?</p>
+              <ul class="p-inline-list">
+                <li class="p-inline-list__item">
+                  <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/aca5f600-Helpful-yes.svg" alt="Positive response" data-feedback-value="positive">
+                  <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/784c0dc9-Helpful-yes-green.svg" alt="" data-feedback-value="positive">
+                </li>
+                <li class="p-inline-list__item">
+                  <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/5dacff00-Helpful-unsure.svg" alt="Neutral response" data-feedback-value="neutral">
+                  <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/b601b52c-Helpful-unsure-orange.svg" alt="" data-feedback-value="neutral">
+                </li>
+                <li class="p-inline-list__item">
+                  <img class="p-tutorial__feedback-icon" src="https://assets.ubuntu.com/v1/4ff77e8e-Helpful-no.svg" alt="Negative response" data-feedback-value="negative">
+                  <img class="p-tutorial__feedback-icon has-color" src="https://assets.ubuntu.com/v1/b45bf2a3-Helpful-no-red.svg" alt="" data-feedback-value="negative">
+                </li>
+              </ul>
+            </div>
+            <div class="p-tutorial__feedback-result p-notification--positive u-hide">
+              <div class="p-notification__content">
+                <p class="p-notification__message">Thank you for your feedback.</p>
+              </div>
+            </div>
+          {% endif %}
+          
+          <hr class="u-sv3">
+          <footer class="p-tutorial-section__footer row u-no-padding--left u-no-padding--right">
+            <div class="col-6 col-small-2 col-medium-3 u-vertically-center">
+              <a class="p-tutorial__bug-link" href="https://discourse.jujucharms.com{{ document.topic_path }}">
+                <small>Suggest changes&nbsp;&rsaquo;</small>
+              </a>
+            </div>
+            <div class="col-6 col-small-2 col-medium-3 u-align--right">
+              <div class="p-tutorial__duration">
+                <small>
+                  <span class="u-hide--small">about</span>
+                  {% if section["remaining_duration"] %}
+                    {{ section["remaining_duration"] }}
+                  {% else %}
+                    0
+                  {% endif %}
+                  minutes to go
+                </small>
+              </div>
+              <div class="p-tutorial__pagination">
+                {% if loop.first %}
+                  <button class="p-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" disabled style="margin-right: 1rem;">
+                    <i class="p-icon--contextual-menu">Previous step</i>
+                  </button>
+                {% else %}
+                  <a href="#{{ loop.index - 1 }}-{{ loop.previtem['slug'] }}" class="p-tutorial__pagination-item--prev p-button--neutral has-icon u-no-margin--bottom" style="margin-right: 1rem;">
+                    <i class="p-icon--contextual-menu">Previous step</i>
+                  </a>
+                {% endif %}
+
+                {% if loop.last %}
+                  <button class="p-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom" disabled>
+                    <i class="p-icon--contextual-menu">Next step</i>
+                  </button>
+                {% else %}
+                  <a href="#{{ loop.index + 1 }}-{{ loop.nextitem['slug'] }}" class="p-tutorial__pagination-item--next p-button--neutral has-icon u-no-margin--bottom">
+                    <i class="p-icon--contextual-menu">Next step</i>
+                  </a>
+                {% endif %}
+              </div>
+            </div>
+          </footer>
+        </section>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+
+
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -43,7 +43,7 @@ def utility_processor():
 
 
 @app.route("/")
-def index_temp():
+def index():
     return render_template("index.html")
 
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,8 +4,11 @@ import talisker.requests
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam import image_template
 from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
+from canonicalwebteam.templatefinder import TemplateFinder
 
 from flask import render_template, make_response
+
+from webapp.tutorials.views import init_tutorials
 
 # Rename your project below
 app = FlaskBase(
@@ -32,6 +35,10 @@ main_docs = Docs(
 )
 main_docs.init_app(app)
 
+template_finder_view = TemplateFinder.as_view("template_finder")
+app.add_url_rule("/", view_func=template_finder_view)
+app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
+init_tutorials(app, "/tutorials")
 
 @app.context_processor
 def utility_processor():

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -4,7 +4,6 @@ import talisker.requests
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam import image_template
 from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
-from canonicalwebteam.templatefinder import TemplateFinder
 
 from flask import render_template, make_response
 
@@ -35,10 +34,8 @@ main_docs = Docs(
 )
 main_docs.init_app(app)
 
-template_finder_view = TemplateFinder.as_view("template_finder")
-app.add_url_rule("/", view_func=template_finder_view)
-app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 init_tutorials(app, "/tutorials")
+
 
 @app.context_processor
 def utility_processor():
@@ -46,7 +43,7 @@ def utility_processor():
 
 
 @app.route("/")
-def index():
+def index_temp():
     return render_template("index.html")
 
 

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -20,7 +20,7 @@ def init_tutorials(app, url_prefix):
         api_username=DISCOURSE_API_USERNAME,
         get_topics_query_id=2
       ),
-      index_topic_id=3749,
+      index_topic_id=2628,
       url_prefix=url_prefix,
     ),
     document_template="tutorials/tutorial.html",

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -10,64 +10,61 @@ DISCOURSE_API_USERNAME = getenv("DISCOURSE_API_USERNAME")
 
 
 def init_tutorials(app, url_prefix):
-  session = talisker.requests.get_session()
-  tutorials_discourse = Tutorials(
-    parser =TutorialParser(
-      api=DiscourseAPI(
-        base_url="https://discourse.charmhub.io/",
-        session=session,
-        api_key=DISCOURSE_API_KEY,
-        api_username=DISCOURSE_API_USERNAME,
-        get_topics_query_id=2
-      ),
-      index_topic_id=2628,
-      url_prefix=url_prefix,
-    ),
-    document_template="tutorials/tutorial.html",
-    url_prefix=url_prefix,
-    blueprint_name="tutorials",
-  )
-
-  @app.route(url_prefix)
-  def tutorials_index():
-    tutorials_discourse.parser.parse()
-    tutorials_discourse.parser.parse_topic(
-      tutorials_discourse.parser.index_topic
-    )
-
-    tutorials = tutorials_discourse.parser.tutorials
-    topic_list = []
-
-    for item in tutorials:
-      if item["categories"] not in topic_list:
-        topic_list.append(item["categories"])
-      item["categories"] = {
-        "slug": item["categories"],
-        "name": " ".join(
-          [
-            word.capitalize()
-            for word in item["categories"].split("-")
-          ]
+    session = talisker.requests.get_session()
+    tutorials_discourse = Tutorials(
+        parser=TutorialParser(
+            api=DiscourseAPI(
+                base_url="https://discourse.charmhub.io/",
+                session=session,
+                api_key=DISCOURSE_API_KEY,
+                api_username=DISCOURSE_API_USERNAME,
+                get_topics_query_id=2,
+            ),
+            index_topic_id=6105,
+            url_prefix=url_prefix,
         ),
-      }
-
-    topic_list.sort()
-    topics = []
-
-    for topic in topic_list:
-      topics.append(
-        {
-          "slug": topic,
-          "name": " ".join(
-            [word.capitalize() for word in topic.split("-")]
-          ),
-        }
-      )
-    
-    return flask.render_template(
-      "tutorials/index.html",
-      tutorials=tutorials,
-      topics=topics
+        document_template="tutorials/tutorial.html",
+        url_prefix=url_prefix,
+        blueprint_name="tutorials",
     )
-  
-  tutorials_discourse.init_app(app)
+
+    @app.route(url_prefix)
+    def index():
+        tutorials_discourse.parser.parse()
+        tutorials_discourse.parser.parse_topic(
+            tutorials_discourse.parser.index_topic
+        )
+
+        tutorials = tutorials_discourse.parser.tutorials
+        topic_list = []
+        for item in tutorials:
+            if item["categories"] not in topic_list:
+                topic_list.append(item["categories"])
+            item["categories"] = {
+                "slug": item["categories"],
+                "name": " ".join(
+                    [
+                        word.capitalize()
+                        for word in item["categories"].split("-")
+                    ]
+                ),
+            }
+
+        topic_list.sort()
+        topics = []
+
+        for topic in topic_list:
+            topics.append(
+                {
+                    "slug": topic,
+                    "name": " ".join(
+                        [word.capitalize() for word in topic.split("-")]
+                    ),
+                }
+            )
+
+        return flask.render_template(
+            "tutorials/index.html", tutorials=tutorials, topics=topics
+        )
+
+    tutorials_discourse.init_app(app)

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -29,7 +29,7 @@ def init_tutorials(app, url_prefix):
     )
 
     @app.route(url_prefix)
-    def index():
+    def tutorial_index():
         tutorials_discourse.parser.parse()
         tutorials_discourse.parser.parse_topic(
             tutorials_discourse.parser.index_topic

--- a/webapp/tutorials/views.py
+++ b/webapp/tutorials/views.py
@@ -1,0 +1,73 @@
+from os import getenv
+
+import flask
+import talisker.requests
+
+from canonicalwebteam.discourse import DiscourseAPI, TutorialParser, Tutorials
+
+DISCOURSE_API_KEY = getenv("DISCOURSE_API_KEY")
+DISCOURSE_API_USERNAME = getenv("DISCOURSE_API_USERNAME")
+
+
+def init_tutorials(app, url_prefix):
+  session = talisker.requests.get_session()
+  tutorials_discourse = Tutorials(
+    parser =TutorialParser(
+      api=DiscourseAPI(
+        base_url="https://discourse.charmhub.io/",
+        session=session,
+        api_key=DISCOURSE_API_KEY,
+        api_username=DISCOURSE_API_USERNAME,
+        get_topics_query_id=2
+      ),
+      index_topic_id=3749,
+      url_prefix=url_prefix,
+    ),
+    document_template="tutorials/tutorial.html",
+    url_prefix=url_prefix,
+    blueprint_name="tutorials",
+  )
+
+  @app.route(url_prefix)
+  def tutorials_index():
+    tutorials_discourse.parser.parse()
+    tutorials_discourse.parser.parse_topic(
+      tutorials_discourse.parser.index_topic
+    )
+
+    tutorials = tutorials_discourse.parser.tutorials
+    topic_list = []
+
+    for item in tutorials:
+      if item["categories"] not in topic_list:
+        topic_list.append(item["categories"])
+      item["categories"] = {
+        "slug": item["categories"],
+        "name": " ".join(
+          [
+            word.capitalize()
+            for word in item["categories"].split("-")
+          ]
+        ),
+      }
+
+    topic_list.sort()
+    topics = []
+
+    for topic in topic_list:
+      topics.append(
+        {
+          "slug": topic,
+          "name": " ".join(
+            [word.capitalize() for word in topic.split("-")]
+          ),
+        }
+      )
+    
+    return flask.render_template(
+      "tutorials/index.html",
+      tutorials=tutorials,
+      topics=topics
+    )
+  
+  tutorials_discourse.init_app(app)


### PR DESCRIPTION
## Done

- Added tutorials index template
- Added individual tutorial template
- Added logic for fetching tutorials dynamically form https://discourse.charmhub.io/t/charmed-kubeflow-io-tutorials/6105
- Originally requested as per [doc](https://docs.google.com/document/d/1YetdDlPGhz13jYG748DYsmIMlnaI6pA4glGzCsImzzA/edit#) _(Note that the list of tutorials is out of date, see [comment](https://docs.google.com/document/d/1YetdDlPGhz13jYG748DYsmIMlnaI6pA4glGzCsImzzA/edit?disco=AAAAXbFJeoI))_


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8046/tutorials
- See that the page renders as expected
- Click on any tutorial and see that it renders as expected
- Test pagination 
- Test feedback icons on final page of any tutorial


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4992 https://github.com/canonical-web-and-design/web-squad/issues/4991